### PR TITLE
Fix 404 error on SPA routes by adding vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
This pull request adds a vercel.json file with a rewrite rule to redirect all routes to index.html. This ensures that React Router handles routing in production and prevents 404 errors on refresh or deep links.
